### PR TITLE
Replacing deprecated 3bit/setup-hcloud action:

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     timeout-minutes: 300
     steps:
       - name: Install and cache Hetzner Cloud CLI
-        uses: 3bit/setup-hcloud@v2
+        uses: hetznercloud/setup-hcloud@v1
       - name: Create mina-build-system-amd64 cloud VM
         run: hcloud server create --name mina-build-system-amd64 --datacenter fsn1-dc14 --primary-ipv4 85665538 --image 228235776 --type cpx41 --ssh-key app@o1labs.org --start-after-create
         env:
@@ -56,7 +56,7 @@ jobs:
     timeout-minutes: 300
     steps:
       - name: Install and cache Hetzner Cloud CLI
-        uses: 3bit/setup-hcloud@v2
+        uses: hetznercloud/setup-hcloud@v1
       - name: Create mina-build-system-arm64 cloud VM
         run: hcloud server create --name mina-build-system-arm64 --datacenter fsn1-dc14 --primary-ipv4 85665558 --image 228228545 --type cax31 --ssh-key app@o1labs.org --start-after-create
         env:
@@ -103,7 +103,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Install and cache Hetzner Cloud CLI
-        uses: 3bit/setup-hcloud@v2
+        uses: hetznercloud/setup-hcloud@v1
       - name: Create mina-build-system-arm64 cloud VM
         run: hcloud server create --name mina-build-system-arm64 --datacenter fsn1-dc14 --primary-ipv4 85665558 --image 228228545 --type cax31 --ssh-key app@o1labs.org --start-after-create
         env:


### PR DESCRIPTION
This action, which allows to interact with Hetzner Cloud, has been deprecated. This PR is a 'put in' replacement of the former Action with Hetzner's official one

This tackles issue: https://github.com/o1-labs/mina-lightnet-docker/issues/11