### PR TITLE
Remove cron job for now, not to introduce instability in this period of time

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,5 @@
 name: Build and publish Mina lightweight network Docker images
 on:
-  schedule:
-    - cron: "30 1 * * *"
   workflow_dispatch: {}
 jobs:
   build-and-publish-amd64:


### PR DESCRIPTION
We need to control auto pushes better. master branch of mina barely changes over time. We are still using -latest suffix which overrides old image. We need to rebuild and repush only when we are certain nothing is broken. Until then i'm disabling auto push and after regrouping we will come with solution