### PR TITLE
Fix PROOF_LEVEL validation for lightnet images

### DIFF
--- a/configuration/Dockerfile
+++ b/configuration/Dockerfile
@@ -7,6 +7,7 @@ ARG ARCHIVE_NODE_API_VERSION=0.0.8
 ARG MINA_PROFILE=devnet
 # Extra profile like lightnet
 ARG MINA_EXTRA_PROFILE
+ARG PROOF_LEVEL=full
 
 ENV NODE_VERSION=20.11.1
 ARG TARGETARCH
@@ -89,7 +90,9 @@ EXPOSE 8282
 
 ENV RUN_ARCHIVE_NODE="true"
 ENV NETWORK_TYPE="single-node"
-ENV PROOF_LEVEL="full"
+ENV PROOF_LEVEL="${PROOF_LEVEL}"
+# Record the compile-time proof level so the entrypoint can validate runtime overrides
+ENV COMPILED_PROOF_LEVEL="${PROOF_LEVEL}"
 ENV LOG_LEVEL="Trace"
 ENV POSTGRES_USER=postgres
 ENV POSTGRES_PASSWORD=postgres

--- a/scripts/spinup-testnet.sh
+++ b/scripts/spinup-testnet.sh
@@ -96,6 +96,18 @@ export MINA_EXE=mina
 export ARCHIVE_EXE=mina-archive
 export LOGPROC_EXE=mina-logproc
 
+# Validate that the requested proof level is compatible with the compiled binary
+if [[ -n "${COMPILED_PROOF_LEVEL}" ]] && [[ "${PROOF_LEVEL}" != "${COMPILED_PROOF_LEVEL}" ]]; then
+  echo ""
+  echo "ERROR: Requested PROOF_LEVEL='${PROOF_LEVEL}' is not compatible with this image."
+  echo "       This image was built with proof_level='${COMPILED_PROOF_LEVEL}'."
+  if [[ "${COMPILED_PROOF_LEVEL}" == "none" ]]; then
+    echo "       This is a lightnet image (no proofs). Use the devnet image for PROOF_LEVEL=full."
+  fi
+  echo ""
+  exit 1
+fi
+
 if [[ $NETWORK_TYPE == "single-node" ]]; then
 
   # Redirect 8080 to 3101 (daemon rest port) for single-node networks


### PR DESCRIPTION
## Summary
- The lightnet image was compiled with `proof_level=none` but the Dockerfile hardcoded `PROOF_LEVEL="full"` as the runtime default, causing the daemon to crash with `Proof level full is not compatible with compile-time proof level none`
- Accept `PROOF_LEVEL` as a Docker build arg so the default matches the compiled binary (`none` for lightnet, `full` for devnet)
- Store `COMPILED_PROOF_LEVEL` env var at build time and validate against it at container startup, failing fast with a clear error message

## Test plan
- [x] Verified locally: lightnet image with `PROOF_LEVEL=full` now exits immediately with clear error: `ERROR: Requested PROOF_LEVEL='full' is not compatible with this image. This is a lightnet image (no proofs). Use the devnet image for PROOF_LEVEL=full.`
- [x] Verified locally: lightnet image with default `PROOF_LEVEL` (now correctly `none`) starts and syncs normally
- [ ] CI integration test passes

Fixes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)