### PR TITLE
Test both lightnet and devnet images in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,17 +8,25 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image-tag: develop-latest-lightnet
+            proof-level: none
+          - image-tag: develop-latest-devnet
+            proof-level: full
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Build Docker image locally
+      - name: Build Docker images locally
         run: |
           ./scripts/build-all.sh \
             --mina-release nightly \
             --target-branches develop \
             --docker-hub-user test-local \
             --skip-push
-      - name: Run integration tests
-        run: ./scripts/test-image.sh test-local/mina-local-network:develop-latest-lightnet
+      - name: Run integration tests (${{ matrix.image-tag }}, proof-level=${{ matrix.proof-level }})
+        run: ./scripts/test-image.sh test-local/mina-local-network:${{ matrix.image-tag }} ${{ matrix.proof-level }}

--- a/configuration/Dockerfile
+++ b/configuration/Dockerfile
@@ -7,6 +7,7 @@ ARG ARCHIVE_NODE_API_VERSION=0.0.8
 ARG MINA_PROFILE=devnet
 # Extra profile like lightnet
 ARG MINA_EXTRA_PROFILE
+ARG PROOF_LEVEL=full
 
 ENV NODE_VERSION=20.11.1
 ARG TARGETARCH
@@ -89,7 +90,9 @@ EXPOSE 8282
 
 ENV RUN_ARCHIVE_NODE="true"
 ENV NETWORK_TYPE="single-node"
-ENV PROOF_LEVEL="full"
+ENV PROOF_LEVEL="${PROOF_LEVEL}"
+# Record the compile-time proof level so the entrypoint can validate runtime overrides
+ENV COMPILED_PROOF_LEVEL="${PROOF_LEVEL}"
 ENV LOG_LEVEL="Trace"
 ENV POSTGRES_USER=postgres
 ENV POSTGRES_PASSWORD=postgres

--- a/scripts/spinup-testnet.sh
+++ b/scripts/spinup-testnet.sh
@@ -96,6 +96,18 @@ export MINA_EXE=mina
 export ARCHIVE_EXE=mina-archive
 export LOGPROC_EXE=mina-logproc
 
+# Validate that the requested proof level is compatible with the compiled binary
+if [[ -n "${COMPILED_PROOF_LEVEL}" ]] && [[ "${PROOF_LEVEL}" != "${COMPILED_PROOF_LEVEL}" ]]; then
+  echo ""
+  echo "ERROR: Requested PROOF_LEVEL='${PROOF_LEVEL}' is not compatible with this image."
+  echo "       This image was built with proof_level='${COMPILED_PROOF_LEVEL}'."
+  if [[ "${COMPILED_PROOF_LEVEL}" == "none" ]]; then
+    echo "       This is a lightnet image (no proofs). Use the devnet image for PROOF_LEVEL=full."
+  fi
+  echo ""
+  exit 1
+fi
+
 if [[ $NETWORK_TYPE == "single-node" ]]; then
 
   # Redirect 8080 to 3101 (daemon rest port) for single-node networks

--- a/scripts/test-image.sh
+++ b/scripts/test-image.sh
@@ -3,10 +3,11 @@
 set -euo pipefail
 
 # Integration test for Mina Lightnet Docker image
-# Usage: ./scripts/test-image.sh <docker-image-name>
+# Usage: ./scripts/test-image.sh <docker-image-name> [proof-level]
 #
-# Example:
-#   ./scripts/test-image.sh test-local/mina-local-network:develop-latest-lightnet
+# Examples:
+#   ./scripts/test-image.sh test-local/mina-local-network:develop-latest-lightnet none
+#   ./scripts/test-image.sh test-local/mina-local-network:develop-latest-devnet full
 
 CONTAINER_NAME="mina-lightnet-test"
 DAEMON_PORT=8080
@@ -18,10 +19,20 @@ DAEMON_URL="http://127.0.0.1:${DAEMON_PORT}/graphql"
 ACCOUNTS_MANAGER_URL="http://127.0.0.1:${ACCOUNTS_MANAGER_PORT}"
 ARCHIVE_API_URL="http://127.0.0.1:${ARCHIVE_API_PORT}"
 
-SYNC_MAX_ATTEMPTS=60
-SYNC_SLEEP=10
-TX_MAX_ATTEMPTS=30
-TX_SLEEP=10
+PROOF_LEVEL="${2:-none}"
+
+# Adjust timeouts based on proof level (full proofs are much slower)
+if [[ "${PROOF_LEVEL}" == "full" ]]; then
+  SYNC_MAX_ATTEMPTS=120
+  SYNC_SLEEP=10
+  TX_MAX_ATTEMPTS=60
+  TX_SLEEP=10
+else
+  SYNC_MAX_ATTEMPTS=60
+  SYNC_SLEEP=10
+  TX_MAX_ATTEMPTS=30
+  TX_SLEEP=10
+fi
 
 TESTS_PASSED=0
 TESTS_FAILED=0
@@ -57,8 +68,9 @@ graphql_query() {
 
 # --- Main ---
 
-if [[ $# -ne 1 ]]; then
-  echo "Usage: $0 <docker-image-name>"
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $0 <docker-image-name> [proof-level]"
+  echo "  proof-level: none (default) or full"
   exit 1
 fi
 
@@ -66,6 +78,7 @@ IMAGE="$1"
 
 echo "=== Mina Lightnet Docker Integration Test ==="
 echo "Image: ${IMAGE}"
+echo "Proof level: ${PROOF_LEVEL}"
 echo ""
 
 # Step 1: Start the container
@@ -78,7 +91,7 @@ docker run -d \
   -p "${ARCHIVE_API_PORT}:${ARCHIVE_API_PORT}" \
   -p "${POSTGRES_PORT}:${POSTGRES_PORT}" \
   --env NETWORK_TYPE=single-node \
-  --env PROOF_LEVEL=none \
+  --env PROOF_LEVEL="${PROOF_LEVEL}" \
   --env RUN_ARCHIVE_NODE=true \
   --env LOG_LEVEL=Info \
   "${IMAGE}"


### PR DESCRIPTION
## Summary
- Run integration tests against both image profiles in parallel using a matrix strategy:
  - **lightnet** (`proof-level=none`): fast startup, no proofs
  - **devnet** (`proof-level=full`): real proofs, higher timeouts (20min sync, 10min tx archive)
- The test script now accepts an optional `proof-level` argument (`none` or `full`)
- Depends on #18 for the `PROOF_LEVEL` build arg / `COMPILED_PROOF_LEVEL` validation

## Test plan
- [ ] CI lightnet matrix job passes
- [ ] CI devnet matrix job passes (or reveals real issues with full proofs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)