### PR TITLE
Add Mina Lightweight Explorer to Docker image

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,7 @@ Profiles: `devnet` (full proofs), `lightnet` (no proofs)
 | `MINA_PROFILE` | devnet | devnet or lightnet |
 | `ARCHIVE_NODE_API_VERSION` | 0.0.8 | Archive GraphQL API version |
 | `MINA_ACCOUNTS_MANAGER_VERSION` | 0.1.1 | Accounts manager version |
+| `EXPLORER_VERSION` | v0.2.2 | Mina Lightweight Explorer version |
 
 ### Runtime Environment Variables
 
@@ -90,7 +91,8 @@ Profiles: `devnet` (full proofs), `lightnet` (no proofs)
 - **Mina GraphQL** (port 3085): Blockchain queries and transaction submission
 - **Accounts Manager** (port 8181): `GET /acquire-account`, `PUT /release-account`, `GET /list-acquired-accounts`, `PUT /lock-account`, `PUT /unlock-account`
 - **Archive Node API** (port 8282): GraphQL API for historical blockchain data
-- **NGINX** (port 8080): CORS-enabled reverse proxy to Mina GraphQL
+- **NGINX** (port 8080): CORS-enabled reverse proxy to Mina GraphQL + Lightweight Explorer UI
+- **Lightweight Explorer** (port 8080, path /): Web-based block explorer for inspecting blocks, accounts, transactions, and mempool. Source: [mina-lightweight-explorer](https://github.com/o1-labs/mina-lightweight-explorer)
 
 ## Mina Debian Repositories
 

--- a/configuration/Dockerfile
+++ b/configuration/Dockerfile
@@ -8,6 +8,7 @@ ARG MINA_PROFILE=devnet
 # Extra profile like lightnet
 ARG MINA_EXTRA_PROFILE
 ARG PROOF_LEVEL=full
+ARG EXPLORER_VERSION=v0.2.2
 
 ENV NODE_VERSION=20.11.1
 ARG TARGETARCH
@@ -76,6 +77,13 @@ RUN npm install -g mina-archive-node-graphql@${ARCHIVE_NODE_API_VERSION}
 RUN curl -fsSL https://github.com/shimkiv/mina-accounts-manager/releases/download/v${MINA_ACCOUNTS_MANAGER_VERSION}/accounts-manager-${TARGETARCH} -o accounts-manager-${TARGETARCH} \
     && chmod +x accounts-manager-${TARGETARCH} \
     && mv accounts-manager-${TARGETARCH} /usr/local/bin/accounts-manager
+
+# install Mina Lightweight Explorer (static files only, no build step)
+RUN mkdir -p /usr/share/nginx/explorer \
+    && curl -fsSL "https://github.com/o1-labs/mina-lightweight-explorer/archive/refs/tags/${EXPLORER_VERSION}.tar.gz" \
+    | tar -xz --strip-components=1 -C /usr/share/nginx/explorer \
+    && rm -f /usr/share/nginx/explorer/LICENSE /usr/share/nginx/explorer/README.md \
+             /usr/share/nginx/explorer/screenshot-dark.png /usr/share/nginx/explorer/server.js
 
 WORKDIR /root
 

--- a/configuration/nginx.conf
+++ b/configuration/nginx.conf
@@ -23,8 +23,8 @@ http {
     server_name       localhost;
 
     location / {
-      root   html;
-      index  index.html index.htm;
+      root   /usr/share/nginx/explorer;
+      index  index.html;
     }
     #error_page  500 502 503 504 /50x.html;
     #location = /50x.html {

--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -13,6 +13,7 @@ DOCKER_HUB_IMAGE_TAG=""
 ACCOUNTS_MANAGER_VERSION="v1.0.0"
 MINA_PROFILE="devnet"
 MINA_EXTRA_PROFILE=""
+EXPLORER_VERSION="v0.2.2"
 PUSH=1
 NO_CACHE=0
 
@@ -31,6 +32,7 @@ usage() {
   echo "      --mina-profile PROFILE            Mina profile (optional, default: devnet)"
   echo "      --mina-extra-profile EXTRA_PROFILE Extra Mina profile (optional)"
   echo "  -c, --accounts-manager-version PATH   Accounts-Manager version (optional)"
+  echo "      --explorer-version VERSION         Lightweight Explorer version (optional, default: v0.2.2)"
   echo "  -s, --skip-push                       Skip pushing the image to Docker Hub (optional, default: false)"
   echo "      --no-cache                        Disable Docker build cache (optional, default: false)"
   echo "  -h, --help                            Display this help message"
@@ -80,6 +82,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     -c|--accounts-manager-version)
       ACCOUNTS_MANAGER_VERSION="$2"
+      shift 2
+      ;;
+    --explorer-version)
+      EXPLORER_VERSION="$2"
       shift 2
       ;;
     -s|--skip-push)
@@ -192,7 +198,7 @@ if [[ $PUSH -eq 1 ]]; then
   echo ""
   echo "Publishing the Docker image..."
   echo ""
-  docker buildx build --platform ${PLATFORMS} --push ${NO_CACHE_ARG} -t ${DOCKER_HUB_USER_NAME}/mina-local-network:${DOCKER_HUB_IMAGE_TAG} --build-arg="MINA_PROFILE=${MINA_PROFILE}" --build-arg="MINA_REPO=${MINA_REPO}" --build-arg="MINA_BRANCH=${MINA_BRANCH}" --build-arg="ARCHIVE_NODE_API_TAG=${ARCHIVE_NODE_API_VERSION}" --build-arg="MINA_ACCOUNTS_MANAGER_VERSION=${ACCOUNTS_MANAGER_VERSION}" --build-arg="PROOF_LEVEL=${PROOF_LEVEL}" ${EXTRA_PROFILE_ARG} . -f configuration/Dockerfile
+  docker buildx build --platform ${PLATFORMS} --push ${NO_CACHE_ARG} -t ${DOCKER_HUB_USER_NAME}/mina-local-network:${DOCKER_HUB_IMAGE_TAG} --build-arg="MINA_PROFILE=${MINA_PROFILE}" --build-arg="MINA_REPO=${MINA_REPO}" --build-arg="MINA_BRANCH=${MINA_BRANCH}" --build-arg="ARCHIVE_NODE_API_TAG=${ARCHIVE_NODE_API_VERSION}" --build-arg="MINA_ACCOUNTS_MANAGER_VERSION=${ACCOUNTS_MANAGER_VERSION}" --build-arg="PROOF_LEVEL=${PROOF_LEVEL}" --build-arg="EXPLORER_VERSION=${EXPLORER_VERSION}" ${EXTRA_PROFILE_ARG} . -f configuration/Dockerfile
 else
   echo ""
   echo "Skipping the Docker image publishing step as requested."
@@ -217,7 +223,7 @@ else
   echo "Building only for current architecture to enable local loading..."
   echo ""
 
-  docker buildx build --platform linux/${DETECTED_ARCH} --load ${NO_CACHE_ARG} -t ${DOCKER_HUB_USER_NAME}/mina-local-network:${DOCKER_HUB_IMAGE_TAG} --build-arg="MINA_PROFILE=${MINA_PROFILE}" --build-arg="MINA_REPO=${MINA_REPO}" --build-arg="MINA_BRANCH=${MINA_BRANCH}" --build-arg="ARCHIVE_NODE_API_TAG=${ARCHIVE_NODE_API_VERSION}" --build-arg="MINA_ACCOUNTS_MANAGER_VERSION=${ACCOUNTS_MANAGER_VERSION}" --build-arg="PROOF_LEVEL=${PROOF_LEVEL}" ${EXTRA_PROFILE_ARG} . -f configuration/Dockerfile
+  docker buildx build --platform linux/${DETECTED_ARCH} --load ${NO_CACHE_ARG} -t ${DOCKER_HUB_USER_NAME}/mina-local-network:${DOCKER_HUB_IMAGE_TAG} --build-arg="MINA_PROFILE=${MINA_PROFILE}" --build-arg="MINA_REPO=${MINA_REPO}" --build-arg="MINA_BRANCH=${MINA_BRANCH}" --build-arg="ARCHIVE_NODE_API_TAG=${ARCHIVE_NODE_API_VERSION}" --build-arg="MINA_ACCOUNTS_MANAGER_VERSION=${ACCOUNTS_MANAGER_VERSION}" --build-arg="PROOF_LEVEL=${PROOF_LEVEL}" --build-arg="EXPLORER_VERSION=${EXPLORER_VERSION}" ${EXTRA_PROFILE_ARG} . -f configuration/Dockerfile
 fi
 
 END=$(date +%s)

--- a/scripts/test-image.sh
+++ b/scripts/test-image.sh
@@ -174,6 +174,20 @@ else
   fail "PostgreSQL query failed: ${pg_result}"
 fi
 
+# 3e. Lightweight Explorer
+echo "[Lightweight Explorer]"
+explorer_http=$(curl -s -o /dev/null -w "%{http_code}" "http://127.0.0.1:${DAEMON_PORT}/" 2>/dev/null || echo "000")
+if [[ "${explorer_http}" == "200" ]]; then
+  explorer_body=$(curl -s "http://127.0.0.1:${DAEMON_PORT}/" 2>/dev/null || echo "")
+  if [[ "${explorer_body}" == *"Lightweight Mina Explorer"* ]]; then
+    pass "Lightweight Explorer is serving on port ${DAEMON_PORT}"
+  else
+    fail "Port ${DAEMON_PORT} returned 200 but content is not the explorer"
+  fi
+else
+  fail "Lightweight Explorer returned HTTP ${explorer_http}"
+fi
+
 echo ""
 
 # Step 4: Transaction lifecycle


### PR DESCRIPTION
## Summary

- Bundles [mina-lightweight-explorer](https://github.com/o1-labs/mina-lightweight-explorer) (v0.2.2) into the Docker image as static files (~150 KB)
- Serves the explorer UI at `http://localhost:8080/` via the existing NGINX reverse proxy
- The explorer's default GraphQL endpoint (`http://localhost:8080/graphql`) matches our NGINX proxy — works out of the box for both single-node and multi-node

## Changes

- **Dockerfile**: Added `EXPLORER_VERSION` build arg, downloads explorer tarball at build time to `/usr/share/nginx/explorer`
- **nginx.conf**: Changed `location /` root from default html to the explorer directory
- **build-image.sh**: Added `--explorer-version` CLI flag, passes it as build arg
- **test-image.sh**: Added explorer health check (HTTP 200 + content verification)
- **CLAUDE.md**: Updated docs with new build arg and service entry

## Why lightweight explorer over full mina-explorer?

- Zero dependencies, no build step (pure HTML/JS/CSS)
- GraphQL endpoint configurable at runtime in the UI — no rebuild needed
- Minimal image size impact (~150 KB vs full React build)
- Already ships with localhost:8080/graphql as default endpoint

## Test plan

- [ ] Build image locally: `./scripts/build-all.sh --target-branches "develop" --mina-release nightly --docker-hub-user test-local --skip-push`
- [ ] Run container and open `http://localhost:8080/` — should show explorer UI
- [ ] Verify `http://localhost:8080/graphql` still works (CORS proxy)
- [ ] Run integration tests: `./scripts/test-image.sh test-local/mina-local-network:develop-latest-lightnet none`

🤖 Generated with [Claude Code](https://claude.com/claude-code)