### PR TITLE
Remove PR trigger from build-and-publish workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,10 +4,6 @@ on:
     branches:
       - develop
       - main
-  pull_request:
-    branches:
-      - develop
-      - main
   workflow_dispatch: {}
 jobs:
   build-and-publish:
@@ -19,14 +15,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to Docker Hub
-        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
-      - name: Build Docker images
-        if: github.event_name == 'pull_request'
-        run: ./scripts/build-all.sh --mina-release nightly --target-branches develop,compatible,master --archs amd64,arm64 --docker-hub-user o1labs --skip-push
       - name: Build and push Docker images
-        if: github.event_name != 'pull_request'
         run: ./scripts/build-all.sh --mina-release nightly --target-branches develop,compatible,master --archs amd64,arm64 --docker-hub-user o1labs


### PR DESCRIPTION
## Summary

Remove `pull_request` trigger from `build.yml`. PR builds are already covered by `test.yml` which runs lighter single-arch builds with integration tests. The `build.yml` workflow only needs to run on push to develop/main where it publishes to Docker Hub.

This avoids the always-failing `build-and-publish` check on PRs (no Docker Hub credentials available).

🤖 Generated with [Claude Code](https://claude.com/claude-code)