### PR TITLE
Exclude master from Docker builds until generic packages available

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,4 +20,7 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
       - name: Build and push Docker images
-        run: ./scripts/build-all.sh --mina-release nightly --target-branches develop,compatible,master --archs amd64,arm64 --docker-hub-user o1labs
+        # Note: master is excluded because the master Mina branch does not
+        # publish mina-devnet-generic packages to the nightly repo yet.
+        # Re-add master once generic packages are available there.
+        run: ./scripts/build-all.sh --mina-release nightly --target-branches develop,compatible --archs amd64,arm64 --docker-hub-user o1labs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch: {}
 
 jobs:
-  build-and-test:
+  build-and-test-develop:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     strategy:
@@ -26,6 +26,32 @@ jobs:
           ./scripts/build-all.sh \
             --mina-release nightly \
             --target-branches develop \
+            --docker-hub-user test-local \
+            --skip-push
+      - name: Run integration tests (${{ matrix.image-tag }}, proof-level=${{ matrix.proof-level }})
+        run: ./scripts/test-image.sh test-local/mina-local-network:${{ matrix.image-tag }} ${{ matrix.proof-level }}
+
+  build-and-test-compatible:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image-tag: compatible-latest-lightnet
+            proof-level: none
+          - image-tag: compatible-latest-devnet
+            proof-level: full
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build Docker images locally
+        run: |
+          ./scripts/build-all.sh \
+            --mina-release nightly \
+            --target-branches compatible \
             --docker-hub-user test-local \
             --skip-push
       - name: Run integration tests (${{ matrix.image-tag }}, proof-level=${{ matrix.proof-level }})


### PR DESCRIPTION
## Summary

Remove `master` from the `--target-branches` list in the build-and-publish workflow.

## Context

We switched from `mina-devnet` to `mina-devnet-generic` (configless variant) in #21 because `mina-devnet` has a broken dependency on `mina-devnet-config` in nightly builds.

The `mina-devnet-generic` package is published to the nightly repo for `develop` and `compatible` branches, but **not for `master`**. This causes the Docker build to fail when building master images:

```
E: Unable to locate package mina-devnet-generic
```

## Resolution

Exclude `master` until the nightly promotion pipeline publishes `mina-devnet-generic` for the master branch. Once available, re-add `master` to the target branches list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)