### PR TITLE
Copy genesis key-pairs into Docker image for account import

### DIFF
--- a/configuration/Dockerfile
+++ b/configuration/Dockerfile
@@ -36,6 +36,10 @@ RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
     && npm --version
 
 COPY ./configuration/mina-local-network/ /root/.mina-network/
+# Copy pre-encrypted genesis account key-pairs for daemon wallet import.
+# The accounts-manager uses MINA_KEYS_PATH to find these files when
+# unlockAccount=true is requested (see spinup-testnet.sh).
+COPY ./configuration/key-pairs/ /root/.mina-network/nodes/whale_0/wallets/store/
 COPY ./configuration/nginx.conf /root/
 
 COPY ./scripts/spinup-testnet.sh /root/


### PR DESCRIPTION
## Summary

The accounts-manager v0.1.2 (from #21) looks for key files at `MINA_KEYS_PATH` to import them into the daemon wallet before unlocking. However, the key files were never actually copied into the Docker image.

The `build-all.sh` script copies key-pairs to a temp folder during build, but that temp folder isn't part of the Docker build context used by `build-image.sh`. The wallet store directories in the image are empty.

This adds a `COPY` instruction to put the ~1000 pre-encrypted key-pairs directly into the wallet store path that `MINA_KEYS_PATH` references.

## Test plan

- [x] CI builds pass
- [x] `GET /acquire-account?unlockAccount=true` returns `{pk, sk}` with the new image
- [x] `sendPayment` mutation works with the unlocked account

🤖 Generated with [Claude Code](https://claude.com/claude-code)