### PR TITLE
Install lightnet variant deb when MINA_EXTRA_PROFILE is set

### DIFF
--- a/configuration/Dockerfile
+++ b/configuration/Dockerfile
@@ -12,8 +12,10 @@ ARG EXPLORER_VERSION=v0.2.2
 
 ARG TARGETARCH
 
-# Build MINA debian package name (use -generic configless variant)
-ENV MINA_DEB_NAME="mina-${MINA_PROFILE}-generic"
+# Build MINA debian package name (use -generic configless variant).
+# When MINA_EXTRA_PROFILE is set (e.g. "lightnet"), append it as a package-name
+# suffix so the corresponding variant deb is installed (mina-mesa-generic-lightnet).
+ENV MINA_DEB_NAME="mina-${MINA_PROFILE}-generic${MINA_EXTRA_PROFILE:+-${MINA_EXTRA_PROFILE}}"
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
## Summary
- Fixes a long-standing bug in `configuration/Dockerfile`: `ARG MINA_EXTRA_PROFILE` was declared but never used. Every published `*-lightnet` image on Docker Hub has actually been installing the same `mina-${profile}-generic` deb as the corresponding `*-devnet` image — the only "lightnet-ness" was the runtime `PROOF_LEVEL=none` env. The standalone `mina-${profile}-generic-lightnet` deb was never installed.
- Verified by running `dpkg -l | grep mina-` inside `o1labs/mina-local-network:compatible-latest-lightnet`: shows `mina-devnet-generic`, not `mina-devnet-generic-lightnet`.
- Uses BuildKit's `${var:+word}` parameter expansion so the suffix is only appended when the arg is set; devnet builds resolve to the same `mina-${profile}-generic` as before.

## Test plan
- [x] Local rebuild against `mesa-preflight` channel — lightnet image now ships `mina-mesa-generic-lightnet 4.0.0-preflight-29042026` (verified via `dpkg -l`).
- [x] Devnet build of the same channel still ships `mina-mesa-generic` (no behaviour change).
- [ ] CI integration test (`scripts/test-image.sh`) passes for `develop-latest-lightnet` and `compatible-latest-lightnet` after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)