### PR TITLE
fix(dockerfile): tolerate weak-security apt errors during nodesource setup

### DIFF
--- a/configuration/Dockerfile
+++ b/configuration/Dockerfile
@@ -32,10 +32,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # install Node.js 20.x LTS (don't pin exact version — nodesource rotates them)
-RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+# AllowWeakRepositories lets nodesource's setup script's internal `apt-get update`
+# tolerate transient "weak security information" errors on Debian's bookworm-updates
+# InRelease — without it the setup aborts and apt silently falls back to Debian's
+# nodejs (which omits npm), breaking the next step.
+RUN echo 'Acquire::AllowWeakRepositories "true";' > /etc/apt/apt.conf.d/99-allow-weak-repos \
+    && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
     && node --version \
-    && npm --version
+    && npm --version \
+    && rm /etc/apt/apt.conf.d/99-allow-weak-repos
 
 COPY ./configuration/mina-local-network/ /root/.mina-network/
 # Copy pre-encrypted genesis account key-pairs for daemon wallet import.


### PR DESCRIPTION
## Summary

The post-merge nightly build on develop is failing on the Node.js install step (`#27` lightnet fix merged at `20e3a1c`, build run [25465335843](https://github.com/o1-labs/mina-lightnet-docker/actions/runs/25465335843)). The failure is independent of lightnet packages and reproduces on `[linux/arm64 3/20]`.

**Root cause:** the `nodesource setup_20.x` script's internal `apt-get update` aborts on Debian's `bookworm-updates` reporting *"weak security information"*. Because the script exits before adding the NodeSource APT source, the next `apt-get install nodejs` silently falls back to Debian's `nodejs 18` — which does NOT bundle `npm` — so the trailing `npm --version` fails with exit code 127 ("command not found").

This was hidden by PR #24 (unpinning the nodejs version): with the explicit pin `nodejs=20.11.1-1nodesource1`, the install would have failed visibly when NodeSource wasn't added; without the pin, apt happily picks Debian's `nodejs 18` and the failure surfaces only at `npm --version`.

**Fix:** drop `Acquire::AllowWeakRepositories=true` into a temporary apt config file during the install, then remove it. This lets the NodeSource setup script's `apt-get update` tolerate the transient weak-security warning and proceed to add the NodeSource source list. The override is scoped to this single `RUN` and removed at the end.

## Test plan

- [ ] Push triggers the `build.yml` workflow on this branch — both `linux/amd64` and `linux/arm64` legs of the multi-arch buildx build complete the Node.js install step
- [ ] `node --version` reports a `v20.x` line (proves NodeSource repo was used, not Debian's 18)
- [ ] `npm --version` succeeds (no more exit 127)
- [ ] Subsequent `npm install -g mina-archive-node-graphql@${ARCHIVE_NODE_API_VERSION}` step still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)