### PR TITLE
feat(docs): add landing page and docs at 8080/, 8080/docs

### DIFF
--- a/configuration/Dockerfile
+++ b/configuration/Dockerfile
@@ -90,6 +90,10 @@ RUN mkdir -p /usr/share/nginx/explorer \
     && rm -f /usr/share/nginx/explorer/LICENSE /usr/share/nginx/explorer/README.md \
              /usr/share/nginx/explorer/screenshot-dark.png /usr/share/nginx/explorer/server.js
 
+# static landing page (/) and docs page (/docs) served by NGINX on port 8080
+COPY ./configuration/landing/ /usr/share/nginx/landing/
+COPY ./configuration/docs/ /usr/share/nginx/docs/
+
 WORKDIR /root
 
 EXPOSE 3085

--- a/configuration/docs/index.html
+++ b/configuration/docs/index.html
@@ -1,0 +1,121 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Mina Lightnet — Docs</title>
+  <style>
+    :root { color-scheme: light dark; }
+    body { font: 15px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+           max-width: 880px; margin: 2.2rem auto; padding: 0 1.2rem; }
+    h1 { margin-bottom: .2rem; }
+    h2 { margin-top: 2rem; border-bottom: 1px solid #8884; padding-bottom: .25rem; }
+    h3 { margin-top: 1.4rem; }
+    code, pre { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+    pre { background: #8881; padding: .8rem 1rem; border-radius: 6px; overflow-x: auto; }
+    code { background: #8881; padding: .1em .35em; border-radius: 3px; }
+    pre code { background: none; padding: 0; }
+    table { border-collapse: collapse; margin: .5rem 0 1rem; }
+    th, td { border: 1px solid #8884; padding: .35rem .7rem; text-align: left; }
+    th { background: #8881; }
+    .muted { color: #888; font-size: .9em; }
+    a { color: #2563eb; }
+    .nav { margin: 1rem 0 2rem; padding: .5rem .8rem; background: #8881; border-radius: 6px; }
+    .nav a { margin-right: 1rem; }
+  </style>
+</head>
+<body>
+  <h1>Mina Lightnet</h1>
+  <p class="muted">Lightweight Mina blockchain network in a single Docker container — for zkApp development and testing.</p>
+
+  <div class="nav">
+    <a href="#connect">Connect</a>
+    <a href="#endpoints">Endpoints</a>
+    <a href="#env">Env Vars</a>
+    <a href="#accounts">Accounts</a>
+    <a href="/explorer/">Explorer</a>
+    <a href="/">Home</a>
+    <a href="#changelog">Changelog</a>
+    <a href="https://github.com/o1-labs/mina-lightnet-docker">GitHub</a>
+  </div>
+
+  <h2 id="connect">Connect Your App</h2>
+  <p>This container is already running. Point your app at the GraphQL endpoint:</p>
+<pre><code>http://127.0.0.1:8080/graphql</code></pre>
+
+  <h3>o1js</h3>
+<pre><code>import { Mina } from 'o1js';
+const network = Mina.Network('http://127.0.0.1:8080/graphql');
+Mina.setActiveInstance(network);</code></pre>
+
+  <h3>Is it ready?</h3>
+  <p>Single-node lightnet syncs in ~1–2 minutes. Check sync status:</p>
+<pre><code>curl -s http://127.0.0.1:8080/graphql \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "{ syncStatus }"}' | jq -r '.data.syncStatus'
+# wait for: SYNCED</code></pre>
+
+  <h2 id="endpoints">Endpoints</h2>
+  <table>
+    <tr><th>Port</th><th>Service</th></tr>
+    <tr><td>3085</td><td>Mina GraphQL (single-node)</td></tr>
+    <tr><td>4001 / 4006</td><td>Whale GraphQL (multi-node)</td></tr>
+    <tr><td>5001</td><td>Fish GraphQL (multi-node)</td></tr>
+    <tr><td>5432</td><td>PostgreSQL archive DB</td></tr>
+    <tr><td>8080</td><td>NGINX proxy (recommended) — GraphQL at <code>/graphql</code>, Explorer at <code>/</code>, this page at <code>/docs</code></td></tr>
+    <tr><td>8181</td><td>Mina Accounts Manager</td></tr>
+    <tr><td>8282</td><td>Archive Node API</td></tr>
+  </table>
+
+  <h2 id="env">Environment Variables</h2>
+  <table>
+    <tr><th>Variable</th><th>Default</th><th>Description</th></tr>
+    <tr><td><code>NETWORK_TYPE</code></td><td><code>single-node</code></td><td><code>single-node</code> or <code>multi-node</code></td></tr>
+    <tr><td><code>PROOF_LEVEL</code></td><td><code>full</code></td><td><code>full</code> or <code>none</code> (lightnet only)</td></tr>
+    <tr><td><code>LOG_LEVEL</code></td><td><code>Trace</code></td><td>Trace / Debug / Info / Warn / Error</td></tr>
+    <tr><td><code>RUN_ARCHIVE_NODE</code></td><td><code>true</code></td><td>Run archive node + PostgreSQL</td></tr>
+    <tr><td><code>SLOT_TIME</code></td><td><code>20000</code></td><td>Block slot time (ms)</td></tr>
+  </table>
+
+  <h2 id="accounts">Accounts Manager (port 8181)</h2>
+  <table>
+    <tr><th>Method</th><th>Endpoint</th><th>Description</th></tr>
+    <tr><td>GET</td><td><code>/acquire-account</code></td><td>Get an unused account (<code>?unlockAccount=true</code> to unlock)</td></tr>
+    <tr><td>PUT</td><td><code>/release-account</code></td><td>Return an account to the pool</td></tr>
+    <tr><td>GET</td><td><code>/list-acquired-accounts</code></td><td>List acquired accounts</td></tr>
+    <tr><td>PUT</td><td><code>/lock-account</code></td><td>Lock an account on the daemon</td></tr>
+    <tr><td>PUT</td><td><code>/unlock-account</code></td><td>Unlock an account on the daemon</td></tr>
+  </table>
+<pre><code>curl http://127.0.0.1:8181/acquire-account
+# { "pk": "B62q...", "sk": "EKE..." }</code></pre>
+
+  <h2 id="changelog">Changelog</h2>
+  <p class="muted">Most recent first. Full history: <code>git log</code> in the repo.</p>
+  <ul>
+    <li><b>fix-nodejs-apt-weak-security</b> — Tolerate weak-security apt errors during nodesource setup so Node.js 20 installs reliably.</li>
+    <li><b>#27</b> — Install <code>lightnet</code> variant deb when <code>MINA_EXTRA_PROFILE</code> is set.</li>
+    <li><b>#26</b> — Copy genesis key-pairs into the Docker image with correct (0700/0600) permissions.</li>
+    <li><b>#25</b> — Copy genesis key-pairs into the Docker image for account import.</li>
+    <li><b>#24</b> — Unpin Node.js version (nodesource rotates exact versions).</li>
+    <li><b>#23</b> — Exclude <code>master</code> from Docker builds until generic packages are available.</li>
+    <li><b>#21</b> — Enable account import for daemon-side signing.</li>
+    <li><b>#20</b> — Add Mina Lightweight Explorer to the Docker image (served at <code>/</code> on 8080).</li>
+    <li><b>#19</b> — Test both lightnet and devnet images in CI.</li>
+    <li><b>#18</b> — Fix <code>PROOF_LEVEL</code> validation for lightnet images.</li>
+    <li><b>#17</b> — Add AI-friendly project documentation.</li>
+    <li><b>#16</b> — Add integration test for Docker image.</li>
+    <li><b>#15</b> — Adjust CI: build on PR, push on main branch.</li>
+    <li><b>#13</b> — Docker build refreshment.</li>
+  </ul>
+
+  <h2>Links</h2>
+  <ul>
+    <li><a href="https://github.com/o1-labs/mina-lightnet-docker">mina-lightnet-docker on GitHub</a></li>
+    <li><a href="https://docs.minaprotocol.com/zkapps/testing-zkapps-lightnet">Testing zkApps with Lightnet</a></li>
+    <li><a href="https://github.com/MinaProtocol/mina">Mina Protocol</a></li>
+    <li><a href="https://github.com/o1-labs/o1js">o1js</a></li>
+  </ul>
+
+  <p class="muted">Served from the container by NGINX on port 8080 at <code>/docs</code>.</p>
+</body>
+</html>

--- a/configuration/landing/index.html
+++ b/configuration/landing/index.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Mina Lightnet</title>
+  <style>
+    :root { color-scheme: light dark; }
+    body { font: 15px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+           max-width: 760px; margin: 4rem auto; padding: 0 1.2rem; }
+    h1 { margin: 0 0 .3rem; font-size: 2rem; }
+    .tag { color: #888; margin-bottom: 2.2rem; }
+    .cards { display: grid; gap: 1rem; grid-template-columns: 1fr; }
+    @media (min-width: 640px) { .cards { grid-template-columns: 1fr 1fr; } }
+    .card { display: block; padding: 1.1rem 1.2rem; border: 1px solid #8884;
+            border-radius: 10px; text-decoration: none; color: inherit;
+            transition: border-color .15s, transform .15s; }
+    .card:hover { border-color: #2563eb; transform: translateY(-1px); }
+    .card h2 { margin: 0 0 .25rem; font-size: 1.05rem; }
+    .card p { margin: 0; color: #888; font-size: .92rem; }
+    .endpoint { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+                font-size: .85rem; color: #2563eb; margin-top: .4rem; }
+    footer { margin-top: 2.5rem; color: #888; font-size: .85rem; }
+    footer a { color: #2563eb; }
+  </style>
+</head>
+<body>
+  <h1>Mina Lightnet</h1>
+  <p class="tag">Lightweight Mina blockchain network running locally in this container.</p>
+
+  <div class="cards">
+    <a class="card" href="/docs/">
+      <h2>📖 Docs</h2>
+      <p>Quick start, endpoints, environment variables, accounts manager API, changelog.</p>
+      <div class="endpoint">/docs/</div>
+    </a>
+    <a class="card" href="/explorer/">
+      <h2>🔍 Explorer</h2>
+      <p>Lightweight block explorer — inspect blocks, accounts, transactions, mempool.</p>
+      <div class="endpoint">/explorer/</div>
+    </a>
+    <a class="card" href="/graphql">
+      <h2>⚡ GraphQL</h2>
+      <p>Mina daemon GraphQL endpoint (CORS-enabled). Point your app here.</p>
+      <div class="endpoint">/graphql</div>
+    </a>
+    <a class="card" href="https://github.com/o1-labs/mina-lightnet-docker">
+      <h2>🔗 GitHub</h2>
+      <p>Source, issues, build scripts.</p>
+      <div class="endpoint">o1-labs/mina-lightnet-docker</div>
+    </a>
+  </div>
+
+  <footer>
+    Other services on this container — Accounts Manager: <code>:8181</code> · Archive API: <code>:8282</code> · PostgreSQL: <code>:5432</code>
+  </footer>
+</body>
+</html>

--- a/configuration/nginx.conf
+++ b/configuration/nginx.conf
@@ -23,9 +23,23 @@ http {
     server_name       localhost;
 
     location / {
-      root   /usr/share/nginx/explorer;
+      root   /usr/share/nginx/landing;
       index  index.html;
     }
+
+    location /explorer/ {
+      alias  /usr/share/nginx/explorer/;
+      index  index.html;
+      try_files $uri $uri/ /explorer/index.html;
+    }
+    location = /explorer { return 301 /explorer/; }
+
+    location /docs/ {
+      alias  /usr/share/nginx/docs/;
+      index  index.html;
+      try_files $uri $uri/ /docs/index.html;
+    }
+    location = /docs { return 301 /docs/; }
     #error_page  500 502 503 504 /50x.html;
     #location = /50x.html {
     #  root  html;

--- a/scripts/test-image.sh
+++ b/scripts/test-image.sh
@@ -174,15 +174,41 @@ else
   fail "PostgreSQL query failed: ${pg_result}"
 fi
 
-# 3e. Lightweight Explorer
-echo "[Lightweight Explorer]"
-explorer_http=$(curl -s -o /dev/null -w "%{http_code}" "http://127.0.0.1:${DAEMON_PORT}/" 2>/dev/null || echo "000")
-if [[ "${explorer_http}" == "200" ]]; then
-  explorer_body=$(curl -s "http://127.0.0.1:${DAEMON_PORT}/" 2>/dev/null || echo "")
-  if [[ "${explorer_body}" == *"Lightweight Mina Explorer"* ]]; then
-    pass "Lightweight Explorer is serving on port ${DAEMON_PORT}"
+# 3e. NGINX-served static pages on port 8080: landing (/), docs (/docs/), explorer (/explorer/)
+echo "[Landing page]"
+landing_http=$(curl -s -o /dev/null -w "%{http_code}" "http://127.0.0.1:${DAEMON_PORT}/" 2>/dev/null || echo "000")
+if [[ "${landing_http}" == "200" ]]; then
+  landing_body=$(curl -s "http://127.0.0.1:${DAEMON_PORT}/" 2>/dev/null || echo "")
+  if [[ "${landing_body}" == *"Mina Lightnet"* ]]; then
+    pass "Landing page is serving on port ${DAEMON_PORT}"
   else
-    fail "Port ${DAEMON_PORT} returned 200 but content is not the explorer"
+    fail "Port ${DAEMON_PORT} / returned 200 but content is not the landing page"
+  fi
+else
+  fail "Landing page returned HTTP ${landing_http}"
+fi
+
+echo "[Docs page]"
+docs_http=$(curl -s -o /dev/null -w "%{http_code}" "http://127.0.0.1:${DAEMON_PORT}/docs/" 2>/dev/null || echo "000")
+if [[ "${docs_http}" == "200" ]]; then
+  docs_body=$(curl -s "http://127.0.0.1:${DAEMON_PORT}/docs/" 2>/dev/null || echo "")
+  if [[ "${docs_body}" == *"Connect Your App"* ]]; then
+    pass "Docs page is serving on port ${DAEMON_PORT}/docs/"
+  else
+    fail "Port ${DAEMON_PORT} /docs/ returned 200 but content is not the docs page"
+  fi
+else
+  fail "Docs page returned HTTP ${docs_http}"
+fi
+
+echo "[Lightweight Explorer]"
+explorer_http=$(curl -s -o /dev/null -w "%{http_code}" "http://127.0.0.1:${DAEMON_PORT}/explorer/" 2>/dev/null || echo "000")
+if [[ "${explorer_http}" == "200" ]]; then
+  explorer_body=$(curl -s "http://127.0.0.1:${DAEMON_PORT}/explorer/" 2>/dev/null || echo "")
+  if [[ "${explorer_body}" == *"Lightweight Mina Explorer"* ]]; then
+    pass "Lightweight Explorer is serving on port ${DAEMON_PORT}/explorer/"
+  else
+    fail "Port ${DAEMON_PORT} /explorer/ returned 200 but content is not the explorer"
   fi
 else
   fail "Lightweight Explorer returned HTTP ${explorer_http}"


### PR DESCRIPTION
Serves a small static hub at / linking to /docs, /explorer, /graphql, and a usage page at /docs (endpoints, env vars, accounts API, changelog). Explorer moves to /explorer/ (relative-path asset refs, safe to relocate) with /explorer and /docs 301-redirecting to their trailing-slash form.