### PR TITLE
ci: one-off mesa-rc1 image build workflow

### DIFF
--- a/.github/workflows/build-mesa-rc1.yml
+++ b/.github/workflows/build-mesa-rc1.yml
@@ -1,0 +1,84 @@
+name: Build and publish Mina Lightnet mesa-rc1 Docker images (one-off)
+
+# Manual-dispatch only. Builds the devnet (full-proof) and lightnet (no-proof)
+# images for the mesa hardfork release candidate, multi-arch (amd64 + arm64),
+# and pushes them to Docker Hub.
+#
+# Profile is "devnet" on purpose: the mesa release branch publishes the
+# devnet-network packages (mina-devnet-generic / mina-archive-devnet) for BOTH
+# amd64 and arm64, whereas the mesa-network packages (mina-mesa*) are amd64-only.
+# Same rc1 source either way; devnet profile is what unblocks arm64.
+#
+# Prerequisite: the mina-devnet-generic / mina-archive-devnet / mina-logproc
+# .debs must already be promoted into the chosen apt component (default: mesa)
+# of the nightly repo for bookworm, or apt-get install will fail.
+on:
+  workflow_dispatch:
+    inputs:
+      mina_branch:
+        description: "apt component in the nightly repo (deb ... bookworm <component>)"
+        required: true
+        default: "mesa"
+      tag_prefix:
+        description: "Docker tag prefix (images become <prefix>-devnet and <prefix>-lightnet)"
+        required: true
+        default: "mesa-rc1"
+      archs:
+        description: "Target architectures (comma-separated)"
+        required: true
+        default: "amd64,arm64"
+      archive_api_version:
+        description: "Archive Node API npm version"
+        required: true
+        default: "0.0.8"
+      accounts_manager_version:
+        description: "Mina Accounts Manager version"
+        required: true
+        default: "0.1.2"
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 300
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU (arm64 emulation)
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USER }}
+          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+
+      - name: Build and push devnet (full proofs)
+        run: |
+          ./scripts/build-image.sh \
+            --archs "${{ inputs.archs }}" \
+            --mina-release nightly \
+            --mina-branch "${{ inputs.mina_branch }}" \
+            --mina-profile devnet \
+            --proof-level full \
+            --archive-api-version "${{ inputs.archive_api_version }}" \
+            --accounts-manager-version "${{ inputs.accounts_manager_version }}" \
+            --docker-user o1labs \
+            --tag "${{ inputs.tag_prefix }}-devnet"
+
+      - name: Build and push lightnet (no proofs)
+        run: |
+          ./scripts/build-image.sh \
+            --archs "${{ inputs.archs }}" \
+            --mina-release nightly \
+            --mina-branch "${{ inputs.mina_branch }}" \
+            --mina-profile devnet \
+            --mina-extra-profile lightnet \
+            --proof-level none \
+            --archive-api-version "${{ inputs.archive_api_version }}" \
+            --accounts-manager-version "${{ inputs.accounts_manager_version }}" \
+            --docker-user o1labs \
+            --tag "${{ inputs.tag_prefix }}-lightnet"


### PR DESCRIPTION
## What

Adds a manual-dispatch (`workflow_dispatch`) GitHub Actions workflow that builds and pushes the **mesa hardfork RC** Docker images for both profiles, multi-arch (amd64 + arm64):

- `o1labs/mina-local-network:mesa-rc1-devnet` — full proofs
- `o1labs/mina-local-network:mesa-rc1-lightnet` — no proofs

## Why

The existing `build.yml` is hard-wired to the standard nightly branches (`develop`/`compatible`) and the default profile derivation. The mesa RC needs a one-off build that:

- pulls from the **nightly repo, `mesa` component** (`deb … bookworm mesa`),
- uses **`--mina-profile devnet`** (`mina-devnet-generic` / `mina-archive-devnet`) — the mesa-network packages (`mina-mesa*`) are **amd64-only**, while the devnet-profile packages from the same RC source cover **both arches**, which is what unblocks arm64.

It uses `build-image.sh` directly (twice) rather than `build-all.sh`, because for a non-standard branch `build-all.sh` would force `--mina-profile mesa` (→ `mina-mesa-generic`).

## Notes

- Inputs (`mina_branch`, `tag_prefix`, `archs`, version args) have sensible defaults so it can be re-targeted without editing the file.
- Adds a `setup-qemu-action` step (required for the arm64 leg on the runner).
- Pushes via the existing `DOCKER_HUB_USER` / `DOCKER_HUB_PASSWORD` secrets.
- **Prerequisite:** the `mina-devnet-generic` / `mina-archive-devnet` / `mina-logproc` `.deb`s (both arches) must already be promoted into `nightly … bookworm mesa`, or `apt-get install` fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)